### PR TITLE
fixed an import exception in pipeline.py

### DIFF
--- a/omegafold/pipeline.py
+++ b/omegafold/pipeline.py
@@ -43,7 +43,7 @@ from omegafold.utils.protein_utils import residue_constants as rc
 
 try:
     from torch.backends import mps  # Compatibility with earlier versions
-except IndexError:
+except ImportError:
     mps = None
 
 


### PR DESCRIPTION
I think the when checking an import from a module the exception that should be catched is `ImportError` not `IndexError`. I changed it in the pipeline file.