### PR TITLE
fixed an import exception in pipeline.py

### DIFF
--- a/omegafold/pipeline.py
+++ b/omegafold/pipeline.py
@@ -43,7 +43,7 @@ from omegafold.utils.protein_utils import residue_constants as rc
 
 try:
     from torch.backends import mps  # Compatibility with earlier versions
-except IndexError:
+except ImportError:
     mps = None
 
 


### PR DESCRIPTION
I think when catching an import exception `ImportError` should be used not `IndexError`.